### PR TITLE
Don't run lint-staged on every execution (#49)

### DIFF
--- a/bin/commands/precommit.js
+++ b/bin/commands/precommit.js
@@ -1,4 +1,4 @@
-const listStaged = require("lint-staged");
 module.exports = () => {
-  listStaged;
+  // eslint-disable-next-line global-require
+  require("lint-staged");
 };


### PR DESCRIPTION
Closes #49

**Pull Request summary**

Run `node bin/index.js`, it shouldn't spit out any extra information about linting or staged files.
